### PR TITLE
Add simple-http-server and qrcode as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,8 @@ setup(
         'Pillow',
         'gpiozero',
         'gphoto2',
+        'simple-http-server,
+        'qrcode',
         ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
         'Pillow',
         'gpiozero',
         'gphoto2',
-        'simple-http-server,
+        'simple-http-server',
         'qrcode',
         ],
 


### PR DESCRIPTION
Without that, you won't be able to start Photobooth and get this kind of error message:
`ModuleNotFoundError: No module named 'qrcode'`